### PR TITLE
Fixed recipes/search

### DIFF
--- a/client/objects/api_version_2/__init__.py
+++ b/client/objects/api_version_2/__init__.py
@@ -389,7 +389,19 @@ class Recipes(BaseAPIv2Object):
 
 
 class RecipesSearch(BaseAPIv2Object):
-    pass
+
+    def get(self, **kwargs):
+        if any(key in ['input', 'output'] for key in kwargs):
+            param = 'input' if 'input' in kwargs else 'output'
+            item_id = kwargs.get(param)
+
+            endpoint_url = self._build_endpoint_base_url()
+            endpoint_url += '?{param}={item_id}'.format(param=param, item_id=item_id)
+
+            return super().get(url=endpoint_url)
+
+        # Fallback to let the official API handle the error cases
+        return super().get(**kwargs)
 
 
 class Skills(BaseAPIv2Object):


### PR DESCRIPTION
Noticed the `recipes/search` endpoint was not allowing the correct parameters to be used (`input` and `output`).

Documentation: https://wiki.guildwars2.com/wiki/API:2/recipes/search