### PR TITLE
Added functionality to use the 'ids' parameter when querying the API

### DIFF
--- a/client/objects/api_version_2/__init__.py
+++ b/client/objects/api_version_2/__init__.py
@@ -6,6 +6,7 @@ class BaseAPIv2Object(BaseAPIObject):
 
     def get(self, **kwargs):
         return super().get(id=kwargs.get('id'),
+                           ids=kwargs.get('ids'),
                            url=kwargs.get('url'),
                            page=kwargs.get('page'),
                            page_size=kwargs.get('page_size')).json()

--- a/client/objects/base_object.py
+++ b/client/objects/base_object.py
@@ -51,11 +51,17 @@ class BaseAPIObject:
             request_url = self._build_endpoint_base_url()
 
             id = kwargs.get('id')
+            ids = kwargs.get('ids')
             page = kwargs.get('page')
             page_size = kwargs.get('page_size')
 
             if id:
                 request_url += '/' + str(id)  # {base_url}/{object}/{id}
+
+            if ids:
+                request_url += '?ids=' # {base_url}/{object}?ids={ids}
+                for id in ids:
+                    request_url += str(id) + ','
 
             if page or page_size:
                 request_url += '?'  # {base_url}/{object}?page={page}&page_size={page_size}
@@ -68,6 +74,7 @@ class BaseAPIObject:
                 request_url += 'page_size={page_size}'.format(page_size=page_size)
 
             request_url.strip('&')  # Remove any trailing ampersand
+            request_url.strip(',')  # Remove any trailing commas from ids
         else:
             request_url = url
 


### PR DESCRIPTION
I was trying to query the colors object of the API to get the entirety of the dyes database from GW2 but couldn't because the `ids` parameter didn't seem to be implemented. I fixed it and tested, seems to work now with no issues.